### PR TITLE
[PHP 7.4 Compatibility] Replace array_key_exists with property_exists during response parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+ ### Changed
+  - Replaced `array_key_exists` with `property_exists` for compatibility with
+    PHP 7.3
 
 ## [1.1.0] - 2019-02-06
 ### Added

--- a/src/PushNotifications.php
+++ b/src/PushNotifications.php
@@ -92,8 +92,8 @@ class PushNotifications {
       $badJSON = $parsedResponse == null;
       if (
         $badJSON ||
-        !isset($parsedResponse->error) ||
-        !isset($parsedResponse->description)
+        !property_exists($parsedResponse, 'error') ||
+        !property_exists($parsedResponse, 'description')
       ) {
         throw new \Exception("An unexpected server error has occurred");
       }

--- a/src/PushNotifications.php
+++ b/src/PushNotifications.php
@@ -25,7 +25,7 @@ class PushNotifications {
     $this->options = $options;
     if (!is_array($this->options)) {
       throw new \Exception("Options parameter must be an array");
-    } 
+    }
     if ($client == null) {
       $this->client = new GuzzleHTTP\Client();
     } else {
@@ -92,8 +92,8 @@ class PushNotifications {
       $badJSON = $parsedResponse == null;
       if (
         $badJSON ||
-        !ARRAY_KEY_EXISTS('error', $parsedResponse) ||
-        !ARRAY_KEY_EXISTS('description', $parsedResponse)
+        !isset($parsedResponse->error) ||
+        !isset($parsedResponse->description)
       ) {
         throw new \Exception("An unexpected server error has occurred");
       }


### PR DESCRIPTION
The current version of the library uses `array_key_exists` on objects, which is deprecated now.

This PR replaces that call with `property_exists` which serves much the same purpose and works identically for dynamic objects such as those returned by `json_decode`.

In the first commit I used `isset` but I opted for `property_exists` as the former will not accept null values, whereas the latter will, like `array_key_exists` would.