### PR TITLE
fix: Update publishToInterests method to support mixed types in $publishRequest

### DIFF
--- a/src/PushNotifications.php
+++ b/src/PushNotifications.php
@@ -102,7 +102,7 @@ class PushNotifications {
 
     /**
      * @param array $interests
-     * @param array<string> $publishRequest
+     * @param array $publishRequest
      * @return mixed
      * @throws \Exception
      */


### PR DESCRIPTION
This PR updates the `publishToInterests` method to support more complex structures by changing the type hint of `$publishRequest` from `array<string>` to `array`. This allows for valid notification payloads like nested arrays for FCM and APNs notifications. 

Resolves issue #[issue-number].
